### PR TITLE
Support protocol to be custom (eg -1 for All)

### DIFF
--- a/aws_ipadd
+++ b/aws_ipadd
@@ -24,6 +24,7 @@ if not profile_name in config:
 config = config[profile_name]
 rule_name = config['rule_name']
 port = int(config['port'])
+protocol = config['protocol']
 security_group_id = config['security_group_id']
 aws_profile = config['aws_profile']
 region_name = config['region_name']
@@ -38,7 +39,7 @@ def allow_ip_permission(security_group_id, ip):
             {
                 'FromPort': port,
                 'ToPort': port,
-                'IpProtocol': 'tcp',
+                'IpProtocol': protocol,
                 'IpRanges': [{'CidrIp': ip, 'Description': rule_name}]
             }])
 
@@ -49,7 +50,7 @@ def revoke_ip_permission(security_group_id, ip):
             {
                 'FromPort': port,
                 'ToPort': port,
-                'IpProtocol': 'tcp',
+                'IpProtocol': protocol,
                 'IpRanges': [{'CidrIp': ip}]
             }])
 

--- a/aws_ipadd
+++ b/aws_ipadd
@@ -24,7 +24,7 @@ if not profile_name in config:
 config = config[profile_name]
 rule_name = config['rule_name']
 port = int(config['port'])
-protocol = config['protocol']
+protocol = config['protocol'] or 'tcp'
 security_group_id = config['security_group_id']
 aws_profile = config['aws_profile']
 region_name = config['region_name']


### PR DESCRIPTION
Supporting non tcp rules eg ALL will be possible by adding protocol as -1 in the config file
The original utility is just wonderful! Thanks for creating this. I needed to modify a rule that contained ALL traffic - which means protocol needs to be -1 and not hardcoded as tcp. Made a minor change that now works for me.
Thought to send back to you to consider it merged.